### PR TITLE
Passage des paquet de loop à liste

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,19 +1,11 @@
 ---
 
 - name: Install requirements (Debian)
-  apt: name={{item}} update_cache=yes
-  with_items:
-  - postfix
-  - ca-certificates
-  - mailutils
-  - libsasl2-modules
+  apt: name=['postfix', 'ca-certificates', 'mailutils', 'libsasl2-modules'] update_cache=yes
 
 - name: Install DKIM requirements (Debian)
-  apt: name={{item}}
+  apt: name=['opendkim', 'opendkim-tools']
   when: postfix_dkim
-  with_items:
-  - opendkim
-  - opendkim-tools
 
 - name: Install postfix-pcre
   apt: pkg=postfix-pcre


### PR DESCRIPTION
Ce passage permet de ne faire la transaction apt qu'une seule fois.
De plus, la méthode loop est dépréciée depuis pas mal de temps.